### PR TITLE
Re-apply latest SDL patch on update.

### DIFF
--- a/updatelibs.sh
+++ b/updatelibs.sh
@@ -11,11 +11,6 @@ if [ ! -d "./SDL/" ]; then
 	echo "SDL folder not found. Cloning now..."
 	hg clone https://hg.libsdl.org/SDL/
 
-	# Apply the IOS_DYLIB=1 / tvOS stub patch for convenience
-	echo ""
-	echo "Applying iOS/tvOS patch for convenience..."
-	cd SDL && hg import --no-commit ../sdl2_fna_ios.patch && cd .. 
-
 	echo ""
 fi
 
@@ -55,6 +50,16 @@ fi
 # Check for updates...
 echo "Updating SDL..."
 cd SDL && hg pull -u && cd ..
+
+# Apply the IOS_DYLIB=1 / tvOS stub patch for convenience
+echo ""
+echo "Applying/Reapply iOS/tvOS patch for convenience..."
+cd SDL 
+# Reset back to pristine
+hg update -r default -C && hg st -un0 | xargs -0 rm 
+# Apply patch
+hg import --no-commit ../sdl2_fna_ios.patch
+cd .. 
 
 echo ""
 echo "Updating SDL_image..."


### PR DESCRIPTION
This moves the patching to a separate step from cloning, "resets" the working directory by removing all outstanding modifications and new untracked, and applies the patch. So now whenever updatelibs.sh is run it should result in a ready to build repository, even if the patch is updated upstream.

The README should be updated as it documents that the patch is only applied on initial clone.