### PR TITLE
Update to pull SDL2 instead of SDL3

### DIFF
--- a/updatelibs.sh
+++ b/updatelibs.sh
@@ -9,7 +9,7 @@
 # Clone repos if needed
 if [ ! -d "./SDL2/" ]; then
 	echo "SDL2 folder not found. Cloning now..."
-	git clone https://github.com/libsdl-org/SDL.git SDL2
+	git clone --branch SDL2 https://github.com/libsdl-org/SDL.git SDL2
 
 	echo ""
 fi


### PR DESCRIPTION
Since SDL2's main branch is now for SDL3, I updated `updatelibs.sh` to pull down the SDL2 branch.